### PR TITLE
Set a CI up

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,19 @@
+name: Android Workflow
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+
+    - name: run tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 29
+        script: ./gradlew connectedCheck


### PR DESCRIPTION
Currently, no continuous integration is set up with the app. This
commit adds a dedicated GitHub Actions workflow which runs tests
on every commit.